### PR TITLE
fix: license & legal consistency across the site

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -86,7 +86,7 @@ export function Footer() {
               </li>
               <li>
                 <Link
-                  href={`${siteConfig.links.github}/website/blob/main/LICENSE`}
+                  href={`${siteConfig.links.github}/${siteConfig.github.repo}/blob/main/LICENSE`}
                   target="_blank"
                   className="hover:text-primary transition-colors"
                 >


### PR DESCRIPTION
## Summary

- Use centralized `siteConfig.github.repo` for the license link in footer instead of hardcoding "website"
- Verified Apache 2.0 License is consistently mentioned across the site:
  - Footer: "Open source under Apache License 2.0."
  - Open Source Section: "Apache 2.0 License"
- Confirmed no "All rights reserved" mentions exist

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)