### PR TITLE
docs: clarify authentication messaging in get-started steps

### DIFF
--- a/components/challenge-selector.tsx
+++ b/components/challenge-selector.tsx
@@ -107,7 +107,8 @@ export function GetStartedSteps({
     {
       number: 2,
       title: "Login to Kubeasy",
-      description: "Authenticate to track your progress and earn XP.",
+      description:
+        "Authenticate with your API token to access challenges and track your progress. Generate a token from your profile page.",
       command: "kubeasy login",
     },
     {


### PR DESCRIPTION
## Summary
- Clarifies the login step description to explain API token authentication
- Users generate tokens from their profile page and use them with the CLI

## Changes
- Updated step 2 description in `/get-started` from "Authenticate to track your progress and earn XP" to "Authenticate with your API token to access challenges and track your progress. Generate a token from your profile page."

## Context
After reviewing the API code in `/app/api/cli/`, confirmed that:
- All CLI routes require Bearer token authentication via `authenticateApiRequest`
- Tokens are verified using Better Auth's `verifyApiKey` API
- Login is mandatory for challenge operations

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced step 2 instructions in the Getting Started guide to clarify API token usage, accessing challenges, and the process for generating tokens from the profile page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->