### PR TITLE
fix(security): prevent banned users from using API keys

### DIFF
--- a/lib/api-auth.ts
+++ b/lib/api-auth.ts
@@ -109,6 +109,18 @@ export async function authenticateApiRequest(
           banned: userResult.banned ?? false,
         };
 
+        // Security check: Reject banned users
+        if (user.banned) {
+          logger.warn("Banned user attempted API access", {
+            userId: user.id,
+            tokenPrefix: token.substring(0, 8),
+          });
+          return {
+            success: false,
+            error: "Account has been banned",
+          };
+        }
+
         logger.info("API request authenticated successfully", {
           userId: user.id,
         });


### PR DESCRIPTION
## 🔒 Security Fix - CRITICAL

### Problem
Banned users were able to continue using their API keys to submit challenges and earn XP even after being banned. This is a critical security vulnerability that allows banned accounts to bypass account restrictions.

### Root Cause
The `authenticateApiRequest()` function in `lib/api-auth.ts` was successfully retrieving the user's `banned` status from the database but **never checking it**. The function would return `success: true` regardless of the ban status.

### Solution
Added a security check immediately after retrieving the user:
```typescript
// Security check: Reject banned users
if (user.banned) {
  logger.warn("Banned user attempted API access", {
    userId: user.id,
    tokenPrefix: token.substring(0, 8),
  });
  return {
    success: false,
    error: "Account has been banned",
  };
}
```

### Impact
- ✅ Banned users now receive `401 Unauthorized` with message "Account has been banned"
- ✅ All ban attempts are logged to Sentry for monitoring
- ✅ Prevents XP farming and challenge submission abuse by banned accounts

### Testing
- [x] Type checking passes
- [x] Code formatting passes (Biome)
- [ ] Manual test: Ban a user and verify API key is rejected

### Security Classification
- **Severity**: 🔴 CRITICAL
- **CVSS**: High (allows banned users to bypass account restrictions)
- **Exploitability**: High (any banned user with existing API key)
- **Recommendation**: Merge and deploy immediately

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Implemented authentication security controls to prevent banned accounts from accessing the system, with clear error messaging provided to affected users indicating their account status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->