### PR TITLE
docs(security): Document why API rate limiting cannot be enabled

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -26,6 +26,16 @@ export const auth = betterAuth({
   plugins: [
     apiKey({
       rateLimit: {
+        // Rate limiting disabled because Better Auth's built-in rate limiting only works
+        // with Better Auth's built-in endpoints (/api-key/verify), not when calling
+        // auth.api.verifyApiKey() programmatically in custom API routes.
+        //
+        // Tested behavior:
+        // - No rate limit headers are returned (x-ratelimit-limit, x-ratelimit-remaining)
+        // - No rate limiting is enforced even when enabled
+        //
+        // Alternative solution would be to use enableSessionForAPIKeys + auth.api.getSession()
+        // or implement custom rate limiting middleware.
         enabled: false,
       },
     }),


### PR DESCRIPTION
## Summary
Comprehensive investigation and documentation of Better Auth's API rate limiting limitations.

## Problem
Better Auth's built-in rate limiting feature only works with Better Auth's built-in endpoints (e.g., `/api-key/verify`), not when calling `auth.api.verifyApiKey()` programmatically in custom API routes.

## Testing Performed
- Created test API token via Playwright automation
- Made 10 consecutive API requests to `/api/trpc/apiKey.list`
- Observed: NO rate limit headers returned (`x-ratelimit-limit`, `x-ratelimit-remaining`)
- Confirmed: No rate limiting enforcement even with correct configuration

## Changes
Added comprehensive documentation in `lib/auth.ts` explaining:
- Why rate limiting is disabled
- What was tested and confirmed
- Alternative approaches:
  - Use `enableSessionForAPIKeys` + `auth.api.getSession()`
  - Implement custom rate limiting middleware

## Alternative Solutions (Not Implemented)
1. **Use enableSessionForAPIKeys**: Would require major refactoring of all API routes
2. **Custom middleware**: Would duplicate Better Auth's rate limiting logic
3. **Switch to built-in endpoints**: Would require CLI changes to use `/api-key/verify` endpoint

## Decision
Keeping rate limiting disabled with clear documentation is better than implementing a half-working solution that gives false security.

## Test Plan
- [x] Tested with Playwright automation
- [x] Verified no rate limit headers returned
- [x] Confirmed no enforcement even with enabled config
- [x] Documented findings in code comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * API key rate limiting in the authentication service has been disabled. This change impacts authentication flows utilizing programmatic API key verification and custom route implementations. If you require rate limiting protection for your API keys, you should implement custom middleware solutions to enforce these controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->