### PR TITLE
fix(security): Reduce API session expiry from 365 to 30 days

### DIFF
--- a/lib/api-auth.ts
+++ b/lib/api-auth.ts
@@ -116,12 +116,13 @@ export async function authenticateApiRequest(
         span.setAttribute("userId", user.id);
 
         // Create a mock session object for tRPC context
+        // Session expiry: 30 days for better security (previously 365 days)
         const mockSession: Session = {
           id: `api-key-${verifyResult.key.id}`,
           userId: user.id,
           expiresAt:
             verifyResult.key.expiresAt ||
-            new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+            new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
           token: token,
           createdAt: verifyResult.key.createdAt,
           updatedAt: verifyResult.key.updatedAt,


### PR DESCRIPTION
## Summary
Reduces API session expiry from 365 days to 30 days for better security.

## Problem
The mock session created for API key authentication had an excessive expiry of 365 days, which:
- Creates a large window of opportunity if an API key is compromised
- Does not align with security best practices
- Is unnecessarily long for API sessions

## Changes
Modified `lib/api-auth.ts`:
- Changed session expiry from 365 days to 30 days
- Added comment documenting the security improvement
- Applies to mock sessions created during API key verification

## Technical Details
**Before:**
```typescript
expiresAt: verifyResult.key.expiresAt || new Date(Date.now() + 365 * 24 * 60 * 60 * 1000)
```

**After:**
```typescript
expiresAt: verifyResult.key.expiresAt || new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
```

## Impact
- Users will need to re-authenticate more frequently (every 30 days instead of yearly)
- Reduces security risk if API key is compromised
- Does not affect the actual API key expiry (controlled by Better Auth)
- Improves overall security posture

## Test Plan
- [x] Code changes reviewed
- [x] TypeScript compilation successful
- [x] Linting passed
- [x] No breaking changes to API contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Reduced default API session expiration from 365 days to 30 days.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->