### PR TITLE
fix(analytics): Allow resetAnalytics to work when user has opted out

### DIFF
--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -24,6 +24,19 @@ function isPostHogReady(): boolean {
 }
 
 /**
+ * Check if PostHog is initialized (regardless of opt-out status)
+ * Used for operations that should work even when user has opted out (e.g., reset on logout)
+ * @returns true if PostHog is loaded and available
+ */
+function isPostHogInitialized(): boolean {
+  try {
+    return posthog && typeof posthog.reset === "function";
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Safe wrapper for PostHog capture calls with error handling
  * @param eventName - The name of the event to track
  * @param properties - Event properties
@@ -144,9 +157,11 @@ export function identifyUser(
 
 /**
  * Reset PostHog state (call on logout)
+ * Note: Uses isPostHogInitialized() instead of isPostHogReady() to ensure
+ * reset works even when user has opted out of tracking
  */
 export function resetAnalytics() {
-  if (!isPostHogReady()) {
+  if (!isPostHogInitialized()) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- Add `isPostHogInitialized()` helper that only checks if PostHog is loaded
- Update `resetAnalytics()` to use new helper instead of `isPostHogReady()`
- Ensures session state is cleared on logout even when user opted out of tracking

## Context
This is a clean fix for the issue raised in PR #140. The original PR had extensive merge conflicts, so this creates a fresh branch with only the analytics fix.

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [ ] Test logout with analytics opted out - session should be reset

Closes #140 (supersedes it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced analytics reset functionality to operate reliably even when users have opted out of tracking, ensuring consistent analytics state cleanup across all user preference scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->