### PR TITLE
fix: use Turbopack for build to fix Sentry crypto.randomUUID error

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -60,12 +60,13 @@ export default withSentryConfig(nextConfig, {
   // side errors will fail.
   tunnelRoute: "/monitoring",
 
-  // Automatically tree-shake Sentry logger statements to reduce bundle size
-  disableLogger: true,
-
-  // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
-  // See the following for more information:
-  // https://docs.sentry.io/product/crons/
-  // https://vercel.com/docs/cron-jobs
-  automaticVercelMonitors: true,
+  // Webpack-specific options
+  webpack: {
+    // Automatically tree-shake Sentry logger statements to reduce bundle size
+    treeshake: {
+      removeDebugLogging: true,
+    },
+    // Enables automatic instrumentation of Vercel Cron Monitors
+    automaticVercelMonitors: true,
+  },
 });

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "next build",
+    "build": "next build --turbopack",
     "check": "biome check .",
     "check:unsafe": "biome check --write --unsafe .",
     "check:write": "biome check --write .",


### PR DESCRIPTION
## Summary
- Enable `--turbopack` flag for build command to fix Sentry's `crypto.randomUUID()` conflict with Next.js 16's `cacheComponents` prerendering
- Migrate deprecated Sentry options (`disableLogger`, `automaticVercelMonitors`) to new `webpack` namespace

## Context
Sentry's tracing internally uses `crypto.randomUUID()` which conflicts with Next.js 16's prerendering when using webpack. Turbopack has proper support for `cacheComponents` with Sentry (added in Sentry 10.28.0).

## Test plan
- [x] `pnpm build` succeeds without `crypto.randomUUID` errors
- [x] No Sentry deprecation warnings

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Build process now uses Turbopack for faster compilation
  * Optimized Sentry error tracking configuration with improved debug logging handling

* **Chores**
  * Updated error tracking settings organization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->