### PR TITLE
fix: use cookie strategy for OAuth state to fix proxy redirect on pre…

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -24,8 +24,10 @@ export const auth = betterAuth({
   // across different environments (production/preview) that may have separate databases.
   // With "database" strategy, the state created on preview wouldn't be found on production
   // when the OAuth provider redirects to the production callback URL.
+  // storeAccountCookie stores account data in a signed cookie for stateless auth.
   account: {
     storeStateStrategy: "cookie",
+    storeAccountCookie: true,
   },
   database: drizzleAdapter(db, {
     provider: "pg", // or "mysql", "sqlite"
@@ -42,14 +44,13 @@ export const auth = betterAuth({
         : await redis.set(key, value),
     delete: async (key) => {
       await redis.del(key);
-      return null;
     },
   },
   session: {
     cookieCache: {
       enabled: true,
       maxAge: 5 * 60, // 5 minutes - session data cached in cookie
-      refreshCache: false, // Disable stateless refresh
+      strategy: "jwe", // Use JWE for stateless session storage in cookie
     },
   },
   plugins: [


### PR DESCRIPTION
…views

The OAuth proxy was failing on Vercel preview deployments because the default "database" strategy stores the OAuth state in the database. When the OAuth provider redirects to the production callback URL, production couldn't find the state that was created on the preview database (if using Neon branches or separate databases).

Switching to "cookie" strategy fixes this by storing the OAuth state in an encrypted cookie that gets passed through the proxy URL parameters, eliminating the need for shared database state between environments.

This resolves the "please_restart_the_process" error on preview deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cookie-based account state persistence for more consistent OAuth flow handling.
  * Short-lived, encrypted session cookie caching (5-minute max age) to improve performance.
  * Redis-backed secondary session storage for stronger session resilience and failover.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->