### PR TITLE
feat(analytics): track demo to signup conversion via PostHog alias

### DIFF
--- a/app/api/demo/pod-created/route.ts
+++ b/app/api/demo/pod-created/route.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/nextjs";
 import { NextResponse } from "next/server";
+import { trackDemoStepServer } from "@/lib/analytics-server";
 import { getDemoSession, isValidDemoToken } from "@/lib/demo-session";
 import { isRealtimeConfigured, realtime } from "@/lib/realtime";
 import { isRedisConfigured } from "@/lib/redis";
@@ -54,6 +55,9 @@ export async function POST(request: Request) {
     }
 
     logger.info("Demo pod created", { token });
+
+    // Track demo step in PostHog
+    await trackDemoStepServer(token, "pod_created");
 
     // Broadcast demo.pod_created event via Upstash Realtime
     if (isRealtimeConfigured && realtime) {

--- a/app/api/demo/start/route.ts
+++ b/app/api/demo/start/route.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/nextjs";
 import { NextResponse } from "next/server";
+import { trackDemoStepServer } from "@/lib/analytics-server";
 import { getDemoSession, isValidDemoToken } from "@/lib/demo-session";
 import { isRealtimeConfigured, realtime } from "@/lib/realtime";
 import { isRedisConfigured } from "@/lib/redis";
@@ -54,6 +55,9 @@ export async function POST(request: Request) {
     }
 
     logger.info("Demo started", { token });
+
+    // Track demo step in PostHog
+    await trackDemoStepServer(token, "started");
 
     // Broadcast demo.started event via Upstash Realtime
     if (isRealtimeConfigured && realtime) {

--- a/components/demo/demo-content.tsx
+++ b/components/demo/demo-content.tsx
@@ -48,6 +48,13 @@ export function DemoContent() {
     mutate();
   }, [mutate]);
 
+  // Store demo token in localStorage for conversion tracking
+  useEffect(() => {
+    if (session?.token) {
+      localStorage.setItem("kubeasy_demo_token", session.token);
+    }
+  }, [session?.token]);
+
   if (isPending) {
     return <DemoLoadingState />;
   }

--- a/components/posthog-identify.tsx
+++ b/components/posthog-identify.tsx
@@ -34,6 +34,10 @@ export function PostHogIdentify() {
         name: session?.user?.name ?? undefined,
       });
       hasIdentifiedRef.current = true;
+
+      // Clean up demo token from localStorage after identification
+      // The alias has already been created server-side during OAuth callback
+      localStorage.removeItem("kubeasy_demo_token");
     }
 
     // User logged out (session disappeared)

--- a/lib/auth-client.ts
+++ b/lib/auth-client.ts
@@ -11,9 +11,19 @@ export const signInWithSocialProvider = async (
   callbackUrl = "/dashboard",
 ) => {
   try {
+    // Retrieve demo token from localStorage if it exists (for conversion tracking)
+    const demoToken =
+      typeof window !== "undefined"
+        ? localStorage.getItem("kubeasy_demo_token")
+        : null;
+
     const data = await authClient.signIn.social({
       provider,
       callbackURL: callbackUrl,
+      // Pass demo token via additionalData (preserved through OAuth redirect)
+      ...(demoToken && {
+        additionalData: { demoToken },
+      }),
     });
     return data;
   } catch (error) {


### PR DESCRIPTION
## Summary

- Store demo token in localStorage for conversion tracking
- Add `trackDemoStepServer()` for `demo_started` and `demo_pod_created` events
- Add `aliasUserServer()` to link demo session to authenticated user
- Pass demo token through OAuth `additionalData`
- Create PostHog alias in OAuth callback hook
- Clean up localStorage after user identification

This enables tracking the full demo → signup funnel in PostHog by merging anonymous demo events with the authenticated user profile.

## PostHog Funnel

```
demo_created        → Session créée (page load)
      ↓
demo_started        → CLI `kubeasy demo start` terminé  
      ↓
demo_pod_created    → Pod nginx détecté running
      ↓
demo_completed      → Validation passée
      ↓ [alias]
user_signup         → Compte créé (events fusionnés)
```

## Test plan

- [ ] Open `/get-started` in private browsing
- [ ] Verify `localStorage.getItem('kubeasy_demo_token')` is set
- [ ] Complete demo steps
- [ ] Click "Sign up" with GitHub/Google
- [ ] In PostHog Events, verify `$create_alias` event exists
- [ ] Verify user has `demo_*` events in their history

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Added analytics tracking infrastructure for demo session lifecycle events including session initialization and resource operations.
- Improved session management and linkage during user authentication to maintain continuity between demo and authenticated user states.
- Enhanced session data persistence, retrieval, and cleanup mechanisms across authentication transitions and flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->