### PR TITLE
refactor: replace Promise.all with better-all for named parallel tasks

### DIFF
--- a/app/(main)/blog/page.tsx
+++ b/app/(main)/blog/page.tsx
@@ -1,3 +1,4 @@
+import { all } from "better-all";
 import { FileText } from "lucide-react";
 import type { Metadata } from "next";
 import { Suspense } from "react";
@@ -46,10 +47,15 @@ export default async function BlogPage({ searchParams }: BlogPageProps) {
   const currentPage = Math.max(1, Number(page) || 1);
   const selectedCategory = category || null;
 
-  const [{ posts, totalPages, totalPosts }, categories] = await Promise.all([
-    getBlogPosts(currentPage, selectedCategory),
-    getBlogCategories(),
-  ]);
+  const { blogData, categories } = await all({
+    async blogData() {
+      return getBlogPosts(currentPage, selectedCategory);
+    },
+    async categories() {
+      return getBlogCategories();
+    },
+  });
+  const { posts, totalPages, totalPosts } = blogData;
 
   return (
     <div className="w-full overflow-x-hidden">

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import { all } from "better-all";
 import { Clock, Target, TrendingUp, Trophy } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
@@ -131,22 +132,34 @@ async function DashboardContent() {
   const queryClient = getQueryClient();
 
   // Fetch onboarding status and prefetch data for client components
-  const [onboardingStatus] = await Promise.all([
-    queryClient.fetchQuery(trpc.onboarding.getStatus.queryOptions()),
-    prefetch(
-      trpc.userProgress.getCompletionPercentage.queryOptions({
-        splitByTheme: true,
-      }),
-    ),
-    prefetch(
-      trpc.userProgress.getCompletionPercentage.queryOptions({
-        splitByTheme: false,
-      }),
-    ),
-    prefetch(trpc.userProgress.getXpAndRank.queryOptions()),
-    prefetch(trpc.userProgress.getStreak.queryOptions()),
-    prefetch(trpc.theme.list.queryOptions()),
-  ]);
+  const { onboardingStatus } = await all({
+    async onboardingStatus() {
+      return queryClient.fetchQuery(trpc.onboarding.getStatus.queryOptions());
+    },
+    async completionByTheme() {
+      await prefetch(
+        trpc.userProgress.getCompletionPercentage.queryOptions({
+          splitByTheme: true,
+        }),
+      );
+    },
+    async completionTotal() {
+      await prefetch(
+        trpc.userProgress.getCompletionPercentage.queryOptions({
+          splitByTheme: false,
+        }),
+      );
+    },
+    async xpAndRank() {
+      await prefetch(trpc.userProgress.getXpAndRank.queryOptions());
+    },
+    async streak() {
+      await prefetch(trpc.userProgress.getStreak.queryOptions());
+    },
+    async themes() {
+      await prefetch(trpc.theme.list.queryOptions());
+    },
+  });
 
   const isOnboardingComplete =
     onboardingStatus.isComplete || onboardingStatus.steps.hasCompletedChallenge;

--- a/app/(main)/profile/page.tsx
+++ b/app/(main)/profile/page.tsx
@@ -1,3 +1,4 @@
+import { all } from "better-all";
 import { Suspense } from "react";
 import { ProfileApiTokens } from "@/components/profile-api-tokens";
 import { ProfileDangerZone } from "@/components/profile-danger-zone";
@@ -32,10 +33,14 @@ async function ProfileContent() {
   const session = await requireAuth();
 
   // Prefetch data in parallel (prefetch won't throw on error, data will be hydrated to client)
-  await Promise.all([
-    prefetch(trpc.emailPreference.listTopics.queryOptions()),
-    prefetch(trpc.userProgress.getXpAndRank.queryOptions()),
-  ]);
+  await all({
+    async emailPreferences() {
+      await prefetch(trpc.emailPreference.listTopics.queryOptions());
+    },
+    async xpAndRank() {
+      await prefetch(trpc.userProgress.getXpAndRank.queryOptions());
+    },
+  });
 
   // Extract user information
   const user = session.user;


### PR DESCRIPTION
Improves readability by using named tasks instead of positional array destructuring for parallel async operations.