### PR TITLE
chore(deps): remove abandoned tailwindcss-animate, consolidate on tw-…

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -26,7 +26,6 @@
     "postcss",
     "autoprefixer",
     "tailwindcss",
-    "tailwindcss-animate",
     "tw-animate-css",
     "@biomejs/biome",
     "husky",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "sonner": "2.0.7",
     "superjson": "2.2.6",
     "tailwind-merge": "3.5.0",
-    "tailwindcss-animate": "1.0.7",
+    "tw-animate-css": "1.4.0",
     "zod": "4.3.6",
     "zod-openapi": "5.4.6"
   },
@@ -95,7 +95,6 @@
     "prettier": "3.8.1",
     "tailwindcss": "4.2.1",
     "tsx": "4.21.0",
-    "tw-animate-css": "1.4.0",
     "typescript": "5.9.3",
     "vitest": "4.0.18"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,9 +153,9 @@ importers:
       tailwind-merge:
         specifier: 3.5.0
         version: 3.5.0
-      tailwindcss-animate:
-        specifier: 1.0.7
-        version: 1.0.7(tailwindcss@4.2.1)
+      tw-animate-css:
+        specifier: 1.4.0
+        version: 1.4.0
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -223,9 +223,6 @@ importers:
       tsx:
         specifier: 4.21.0
         version: 4.21.0
-      tw-animate-css:
-        specifier: 1.4.0
-        version: 1.4.0
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -4735,11 +4732,6 @@ packages:
 
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
-
-  tailwindcss-animate@1.0.7:
-    resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
-    peerDependencies:
-      tailwindcss: '>=3.0.0 || insiders'
 
   tailwindcss@4.2.1:
     resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
@@ -9378,10 +9370,6 @@ snapshots:
       uuid: 10.0.0
 
   tailwind-merge@3.5.0: {}
-
-  tailwindcss-animate@1.0.7(tailwindcss@4.2.1):
-    dependencies:
-      tailwindcss: 4.2.1
 
   tailwindcss@4.2.1: {}
 


### PR DESCRIPTION
…animate-css

- Remove unused tailwindcss-animate (abandoned since Aug 2023)
- Move tw-animate-css from devDependencies to dependencies (runtime dep)
- Update knip.json to remove tailwindcss-animate from ignoreDependencies

The project was already using tw-animate-css via @import in globals.css. This consolidates on the actively maintained library.

Closes #215

https://claude.ai/code/session_01APb6WF3ZHaDCqsyay41vyb