### PR TITLE
perf: cache challenge.list query to eliminate navigation loading indicator

### DIFF
--- a/server/api/routers/challenge.ts
+++ b/server/api/routers/challenge.ts
@@ -1,5 +1,5 @@
 import { and, eq, ilike, sql } from "drizzle-orm";
-import { cacheLife, cacheTag } from "next/cache";
+import { cacheLife, cacheTag, revalidateTag } from "next/cache";
 import { z } from "zod";
 import type { ChallengeFilters } from "@/schemas/challengeFilters";
 import { challengeFiltersSchema } from "@/schemas/challengeFilters";
@@ -165,6 +165,8 @@ export const challengeRouter = createTRPCRouter({
           .where(eq(challenge.slug, input.slug))
           .returning();
 
+        revalidateTag("challenges", "max");
+
         return {
           success: true,
           challenge: updated,
@@ -187,6 +189,8 @@ export const challengeRouter = createTRPCRouter({
           ofTheWeek: input.ofTheWeek,
         })
         .returning();
+
+      revalidateTag("challenges", "max");
 
       return {
         success: true,
@@ -211,6 +215,8 @@ export const challengeRouter = createTRPCRouter({
 
       // Delete the challenge (cascading will handle related records)
       await ctx.db.delete(challenge).where(eq(challenge.slug, input.slug));
+
+      revalidateTag("challenges", "max");
 
       return {
         success: true,

--- a/server/api/routers/userProgress.ts
+++ b/server/api/routers/userProgress.ts
@@ -838,6 +838,9 @@ export const userProgressRouter = createTRPCRouter({
         .set({ totalXp: xpResult.totalXp })
         .where(eq(userXp.userId, userId));
 
+      revalidateTag(`challenge-list-${userId}`, "max");
+      revalidateTag("challenges", "max");
+
       return {
         success: true,
         message: "Challenge progress reset successfully",


### PR DESCRIPTION
## Summary

- Extracts `challenge.list` tRPC query into a `"use cache"` helper function (`fetchChallengeList`) with `cacheLife("hours")`
- Tags cache entries with `"challenges"` (shared, invalidated on admin sync) and `"challenge-list-{userId}"` (per-user, invalidated on submission)
- Adds `revalidateTag(\`challenge-list-${userId}\`)` in `submitChallenge` so the user's cached list refreshes after completing a challenge
- Restores instant navigation to `/challenges` and `/themes/*` pages that was broken by the previous SSR fix (the outer uncached component was hitting the DB on every request)

## Test plan

- [ ] Navigate to `/challenges` — no browser loading indicator
- [ ] Navigate to `/themes/*` — instant navigation
- [ ] Log in, complete a challenge, navigate back to `/challenges` — updated completion status appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)