### PR TITLE
perf: parallelize DB query and tRPC prefetch in ChallengePage SSR

### DIFF
--- a/app/(main)/challenges/[slug]/page.tsx
+++ b/app/(main)/challenges/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { all } from "better-all";
 import { ArrowLeft, Clock } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
@@ -81,15 +82,19 @@ export default async function ChallengePage({
 }) {
   const { slug } = await params;
 
-  // Access database directly
-  const challenge = await getChallengeBySlug(slug);
+  // Parallelize independent async operations
+  const { challenge } = await all({
+    async challenge() {
+      return getChallengeBySlug(slug);
+    },
+    async objectives() {
+      await prefetch(trpc.challenge.getObjectives.queryOptions({ slug }));
+    },
+  });
 
   if (!challenge) {
     return notFound();
   }
-
-  // Prefetch objectives to avoid loading spinner
-  await prefetch(trpc.challenge.getObjectives.queryOptions({ slug }));
 
   const difficultyLabels: Record<string, string> = {
     easy: "Beginner",


### PR DESCRIPTION
## Summary

- Fixes #235
- Run `getChallengeBySlug` and `prefetch(getObjectives)` concurrently using `better-all`, eliminating a sequential round-trip on the critical SSR path of challenge pages
- Follows the same pattern already used in `dashboard/page.tsx`

## Test plan

- [ ] Navigate to a challenge page and verify it loads correctly
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)